### PR TITLE
インクリメンタルサーチの実装

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  // IntelliSense を使用して利用可能な属性を学べます。
+  // 既存の属性の説明をホバーして表示します。
+  // 詳細情報は次を確認してください: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "プログラムの起動",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "${workspaceFolder}/app/assets/javascripts/users.js"
+    }
+  ]
+}

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,79 @@
+$(function() {
+  function addUser(user) {
+    let html = `
+      <div class="chat-group-user clearfix">
+        <p class="chat-group-user__name">${user.name}</p>
+        <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
+      </div>
+    `;
+    $("#user-search-result").append(html);
+    
+  }
+  function addNoUser() {
+    let html = `
+      <div class="chat-group-user clearfix">
+        <p class="chat-group-user__name">ユーザーが見つかりません</p>
+      </div>
+    `;
+    $("#user-search-result").append(html);
+  }
+
+  function addDeleteUser(name, id) {
+    let html = `
+    <div class="chat-group-user clearfix" id="${id}">
+    <p class="chat-group-user__name">${name}</p>
+    <div class="user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn" data-user-id="${id}" data-user-name="${name}">削除</div>
+    </div>`;
+    $(".js-add-user").append(html);
+  }
+  //userをグループに登録
+  function addMember(userId){
+    let html =`<input value="${userId}" name="group[user_ids][]" type="hidden" id="group_user_ids_${userId}"/>`;
+    $(`#${userId}`).append(html);
+  }
+  //入力のたびにイベントが発火
+  $("#user-search-field").on("keyup", function() {
+    let input = $("#user-search-field").val();
+  
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: { keyword: input },
+      dataType: 'json'
+    })
+      .done(function(users) {  //usersにjson形式のuser変数が代入される
+        $("#user-search-result").empty();   
+        if (users.length !== 0) {
+          users.forEach(function(user) {
+            addUser(user);
+          });
+        } 
+        else if (input.length == 0) {
+        return false;    
+        } 
+        else { 
+          addNoUser();
+        }
+      })
+      .fail(function() {
+        alert("通信エラーです。ユーザーが表示できません。");
+      });
+  });
+
+  $(document).on("click", ".chat-group-user__btn--add",function() {
+    console.log
+    const userName = $(this).attr("data-user-name");
+    const userId = $(this).attr("data-user-id");
+    $(this)
+      .parent()
+      .remove();
+    addDeleteUser(userName,userId);
+    addMember(userId);
+  });
+  //チャットに追加したメンバーを削除する
+  $(document).on("click", ".chat-group-user__btn--remove",function() {
+    $(this)
+      .parent()
+      .remove();
+  });
+});

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -31,7 +31,7 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    params.require(:group).permit(:name, {user_ids: []})
+    params.require(:group).permit(:name, user_ids: [])
   end
 
   def set_group

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,11 @@
 class UsersController < ApplicationController
+  def index
+    @users = User.search(params[:keyword], current_user.id)
+    respond_to do |format|
+      format.html
+      format.json      
+    end
+  end
   def edit
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,8 @@ class User < ApplicationRecord
   has_many :messages
   has_many :group_users
   has_many :groups, through: :group_users
+  def self.search(input, id)
+    return nil if input == ""
+    User.where(['name LIKE ?', "%#{input}%"] ).where.not(id: id).limit(10)
+  end 
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -10,14 +10,32 @@
       = f.label :name, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-  .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+  .chat-group-form__field.cleafix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      #chat-group-users.js-add-user
+        .chat-group-user.crearfix.js-chat-member
+          %input{name: "group[user_ids][]",type: "hidden", value: current_user.id}
+          %p.chat-group-user__name
+            = current_user.name
+
+        -group.users.each do |user|
+          -if current_user.name != user.name
+            .chat-group-user.clearfix.js-chat-member
+              %input{name: "group[user_ids][]",type: "hidden",value: user.id}
+              %p.chat-group-user__name
+                = user.name
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 
+                削除 
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
   .chat-group-form__field.clearfix
     .chat-group-form__field--left

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.name user.name
+  json.id user.id
+end


### PR DESCRIPTION
#what
グループ新規作成・編集画面において、ユーザーをインクリメンタルサーチで検索できるように実装する。テキストフィールドに入力するたびにイベントが発火するようにし、イベント時に非同期通信できるようにする。また、自分が検索メンバーから外れる、メンバーの追加、削除などの機能も実装する。
#why
チャットメンバーを検索しやすくしたり、メンバーの追加、削除などの機能はチャットグループの作成に必要なため