### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -39,7 +39,6 @@ $(function() {
       dataType: 'json',
       processData: false,
       contentType: false
-
     })
     //非同期通信成功時
     .done(function(data) {
@@ -64,19 +63,16 @@ $(function() {
         data:{id: last_message_id}
       })
       .done(function(messages){
-        
         var insertHTML = '';
         messages.forEach(function(message) {
-          insertHTML += buildHTML(message);
+          insertHTML = buildHTML(message);
         }) 
         $('.messages').append(insertHTML);
           $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight},'fast');
-       }
       })
       .fail(function() {
         alert ('自動更新に失敗しました');
       });
-     
     }
   };
   setInterval(reloadMessages, 7000);

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -5,7 +5,7 @@ $(function() {
     var content = message.content ?`${message.content}`:"";
     var image = message.image ? `<img src= "${message.image}">`:"";
     //messageのhtml
-    var html = `<div class ="message" data-id=${message.id}>
+    var html = `<div class ="message" data-message-id="${message.id}">
                   <div class ="upper-message">
                     <div class ="upper-message__user-name">
                       ${message.user_name}
@@ -22,8 +22,7 @@ $(function() {
                   </div>
                 </div>`
 
-    return html;
-         
+    return html;       
   }
   //フォーム送信時にイベントの発火
   $('#new_message').on('submit', function(e) {
@@ -48,11 +47,37 @@ $(function() {
       $('.messages').append(html);
       $('#new_message')[0].reset();
       $('.form__submit').prop('disabled', false);
-      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
-    })
+      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight},);
+    })   
     //非同期通信失敗時
     .fail(function() {
       alert('メッセージ送信に失敗しました');
     });
   });
+  var reloadMessages = function () {
+    if(window.location.href.match(/\/groups\/\d+\/messages/)){
+      var last_message_id = $('.message:last').data('message-id');
+      $.ajax({
+        url: 'api/messages',
+        type: 'GET',
+        dataType: 'json',
+        data:{id: last_message_id}
+      })
+      .done(function(messages){
+        
+        var insertHTML = '';
+        messages.forEach(function(message) {
+          insertHTML += buildHTML(message);
+        }) 
+        $('.messages').append(insertHTML);
+          $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight},'fast');
+       }
+      })
+      .fail(function() {
+        alert ('自動更新に失敗しました');
+      });
+     
+    }
+  };
+  setInterval(reloadMessages, 7000);
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -2,6 +2,6 @@ class Api::MessagesController < ApplicationController
   def index
     group = Group.find(params[:group_id])
     last_message_id = params[:id].to_i
-    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+    @messages = group.messages.includes(:user).where("id > ?",last_message_id)
   end
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
   json.content message.content
   json.image message.image.url
-  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.date message.created_at.strftime("%Y/%m/%d %H:%M")
   json.user_name message.user.name
   json.id message.id
 end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{"data-message-id":"#{message.id}"}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,4 +2,4 @@ json.user_name @message.user.name
 json.content @message.content
 json.image @message.image.url
 json.date @message.created_at.strftime("%Y/%m/%d %H:%M")
-json.message_id @message.id
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
-  end 
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }  
+    end
+  end
 end


### PR DESCRIPTION
#what
自動更新の機能で自分以外のメンバーのメッセージをリロードしなくてもリアルタイムで表示サれるようにする

#why
現在は自分の投稿したメッセージは非同期通信ですぐに表示されているが、他のユーザーのメッセージは非同期通ですぐに追加表示されるような使用になっていないので